### PR TITLE
s/_needs_to_change_config/_needs_to_change_container_config/

### DIFF
--- a/cloud/lxd/lxd_container.py
+++ b/cloud/lxd/lxd_container.py
@@ -546,16 +546,16 @@ class LxdContainerManagement(object):
             'devices': old_metadata['devices'],
             'profiles': old_metadata['profiles']
         }
-        if self._needs_to_change_config('architecture'):
+        if self._needs_to_change_container_config('architecture'):
             body_json['architecture'] = self.config['architecture']
-        if self._needs_to_change_config('config'):
+        if self._needs_to_change_container_config('config'):
             for k, v in self.config['config'].items():
                 body_json['config'][k] = v
-        if self._needs_to_change_config('ephemeral'):
+        if self._needs_to_change_container_config('ephemeral'):
             body_json['ephemeral'] = self.config['ephemeral']
-        if self._needs_to_change_config('devices'):
+        if self._needs_to_change_container_config('devices'):
             body_json['devices'] = self.config['devices']
-        if self._needs_to_change_config('profiles'):
+        if self._needs_to_change_container_config('profiles'):
             body_json['profiles'] = self.config['profiles']
         self._operate_and_wait('PUT', '/1.0/containers/{0}'.format(self.name), body_json=body_json)
         self.actions.append('apply_container_configs')


### PR DESCRIPTION
Fixup for c82cfe8d281cb5472e2e1527d4b979e3145d1773, fixes

``````
An exception occurred during task execution. The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_Sk3DK4/ansible_module_lxd_container.py", line 729, in <module>
    main()
  File "/tmp/ansible_Sk3DK4/ansible_module_lxd_container.py", line 724, in main
    lxd_manage.run()
  File "/tmp/ansible_Sk3DK4/ansible_module_lxd_container.py", line 643, in run
    action()
  File "/tmp/ansible_Sk3DK4/ansible_module_lxd_container.py", line 471, in _started
    self._apply_container_configs()
  File "/tmp/ansible_Sk3DK4/ansible_module_lxd_container.py", line 549, in _apply_container_configs
    if self._needs_to_change_config('architecture'):
AttributeError: 'LxdContainerManagement' object has no attribute '_needs_to_change_config'
 Show all checks
```c82cfe8d281cb5472e2e1527d4b979e3145d1773
``````
